### PR TITLE
Change class option to take strings and document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ var buf = packet.encode({
   flags: packet.RECURSION_DESIRED,
   questions: [{
     type: 'A',
+    class: 'IN',
     name: 'google.com'
   }]
 })
@@ -92,6 +93,7 @@ A question looks like this
 ``` js
 {
   type: 'A', // or SRV, AAAA, etc
+  class: 'IN', // one of IN, CS, CH, HS, ANY. Default: IN
   name: 'google.com' // which record are you looking for
 }
 ```
@@ -101,6 +103,7 @@ And an answers, additional, or authority looks like this
 ``` js
 {
   type: 'A', // or SRV, AAAA, etc
+  class: 'IN', // one of IN, CS, CH, HS
   name: 'google.com', // which name is this record for
   ttl: optionalTimeToLiveInSeconds,
   (record specific data, see below)

--- a/classes.js
+++ b/classes.js
@@ -1,0 +1,23 @@
+'use strict'
+
+exports.toString = function (klass) {
+  switch (klass) {
+    case 1: return 'IN'
+    case 2: return 'CS'
+    case 3: return 'CH'
+    case 4: return 'HS'
+    case 255: return 'ANY'
+  }
+  return 'UNKNOWN_' + klass
+}
+
+exports.toClass = function (name) {
+  switch (name.toUpperCase()) {
+    case 'IN': return 1
+    case 'CS': return 2
+    case 'CH': return 3
+    case 'HS': return 4
+    case 'ANY': return 255
+  }
+  return 0
+}

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const types = require('./types')
 const rcodes = require('./rcodes')
 const opcodes = require('./opcodes')
+const classes = require('./classes')
 const ip = require('ip')
 const Buffer = require('safe-buffer').Buffer
 
@@ -586,7 +587,7 @@ answer.encode = function (a, buf, offset) {
 
   buf.writeUInt16BE(types.toType(a.type), offset)
 
-  let klass = a.class === undefined ? 1 : a.class
+  let klass = classes.toClass(a.class === undefined ? 'IN' : a.class)
   if (a.flush) klass |= FLUSH_MASK // the 1st bit of the class is the flush bit
   buf.writeUInt16BE(klass, offset + 2)
 
@@ -611,7 +612,7 @@ answer.decode = function (buf, offset) {
   a.name = name.decode(buf, offset)
   offset += name.decode.bytes
   a.type = types.toString(buf.readUInt16BE(offset))
-  a.class = buf.readUInt16BE(offset + 2)
+  a.class = classes.toString(buf.readUInt16BE(offset + 2))
   a.ttl = buf.readUInt32BE(offset + 4)
 
   a.flush = !!(a.class & FLUSH_MASK)
@@ -645,7 +646,7 @@ question.encode = function (q, buf, offset) {
   buf.writeUInt16BE(types.toType(q.type), offset)
   offset += 2
 
-  buf.writeUInt16BE(q.class === undefined ? 1 : q.class, offset)
+  buf.writeUInt16BE(classes.toClass(q.class === undefined ? 'IN' : q.class), offset)
   offset += 2
 
   question.encode.bytes = offset - oldOffset
@@ -666,7 +667,7 @@ question.decode = function (buf, offset) {
   q.type = types.toString(buf.readUInt16BE(offset))
   offset += 2
 
-  q.class = buf.readUInt16BE(offset)
+  q.class = classes.toString(buf.readUInt16BE(offset))
   offset += 2
 
   const qu = !!(q.class & QU_MASK)

--- a/test.js
+++ b/test.js
@@ -101,6 +101,7 @@ tape('query', function (t) {
     id: 42,
     questions: [{
       type: 'A',
+      class: 'IN',
       name: 'hello.a.com'
     }, {
       type: 'SRV',
@@ -113,7 +114,7 @@ tape('query', function (t) {
     id: 42,
     questions: [{
       type: 'A',
-      class: 100,
+      class: 'CH',
       name: 'hello.a.com'
     }, {
       type: 'SRV',
@@ -130,10 +131,12 @@ tape('response', function (t) {
     flags: packet.TRUNCATED_RESPONSE,
     answers: [{
       type: 'A',
+      class: 'IN',
       name: 'hello.a.com',
       data: '127.0.0.1'
     }, {
       type: 'SRV',
+      class: 'IN',
       name: 'hello.srv.com',
       data: {
         port: 9090,
@@ -141,6 +144,7 @@ tape('response', function (t) {
       }
     }, {
       type: 'CNAME',
+      class: 'IN',
       name: 'hello.cname.com',
       data: 'hello.other.domain.com'
     }]


### PR DESCRIPTION
This changes to class option to take strings instead of integers, so 1 becomes 'IN', 3 becomes 'CH' and so on. Also documented the class option.

Two questions:

1) Should I reduce the documentation on the option? Given that most people will probably never need that option, we could remove it from the example. On the other hand, this is a low level library so it might just be okay to keep it.
2) This is a breaking change for a undocumented option. Should we still do a major version bump to be safe?

Fixes: https://github.com/mafintosh/dns-packet/issues/3