### PR TITLE
Fix encode/decode for root name ('.')

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,19 +9,23 @@ var NOT_FLUSH_MASK = ~FLUSH_MASK
 var QU_MASK = 1 << 15
 var NOT_QU_MASK = ~QU_MASK
 
-var name = {}
+var name = exports.txt = exports.name = {}
 
-name.encode = function (n, buf, offset) {
+name.encode = function (str, buf, offset) {
   if (!buf) buf = Buffer.allocUnsafe(name.encodingLength(n))
   if (!offset) offset = 0
-
-  var list = n.split('.')
   var oldOffset = offset
 
-  for (var i = 0; i < list.length; i++) {
-    var len = buf.write(list[i], offset + 1)
-    buf[offset] = len
-    offset += len + 1
+  // strip leading and trailing .
+  const n = str.replace(/^\.|\.$/gm, '')
+  if (n.length) {
+    const list = n.split('.')
+
+    for (var i = 0; i < list.length; i++) {
+      var len = buf.write(list[i], offset + 1)
+      buf[offset] = len
+      offset += len + 1
+    }
   }
 
   buf[offset++] = 0
@@ -39,6 +43,10 @@ name.decode = function (buf, offset) {
   var oldOffset = offset
   var len = buf[offset++]
 
+  if (len === 0) {
+    name.decode.bytes = 1
+    return '.'
+  }
   if (len >= 0xc0) {
     var res = name.decode(buf, buf.readUInt16BE(offset - 1) - 0xc000)
     name.decode.bytes = 2

--- a/test.js
+++ b/test.js
@@ -173,6 +173,38 @@ tape('response', function (t) {
   t.end()
 })
 
+tape('name_encoding', function (t) {
+  var data = 'foo.example.com'
+  var buf = Buffer.allocUnsafe(255)
+  var offset = 0
+  packet.name.encode(data, buf, offset)
+  t.ok(packet.name.encode.bytes === 17, 'name encoding length matches')
+  var dd = packet.name.decode(buf, offset)
+  t.ok(data === dd, 'encode/decode matches')
+  offset += packet.name.encode.bytes
+
+  data = 'com'
+  packet.name.encode(data, buf, offset)
+  t.ok(packet.name.encode.bytes === 5, 'name encoding length matches')
+  dd = packet.name.decode(buf, offset)
+  t.ok(data === dd, 'encode/decode matches')
+  offset += packet.name.encode.bytes
+
+  data = 'example.com.'
+  packet.name.encode(data, buf, offset)
+  t.ok(packet.name.encode.bytes === 13, 'name encoding length matches')
+  dd = packet.name.decode(buf, offset)
+  t.ok(data.slice(0, -1) === dd, 'encode/decode matches')
+  offset += packet.name.encode.bytes
+
+  data = '.'
+  packet.name.encode(data, buf, offset)
+  t.ok(packet.name.encode.bytes === 1, 'name encoding length matches')
+  dd = packet.name.decode(buf, offset)
+  t.ok(data === dd, 'encode/decode matches')
+  t.end()
+})
+
 function testEncoder (t, packet, val) {
   var buf = packet.encode(val)
   var val2 = packet.decode(buf)


### PR DESCRIPTION
Fixes #13.
Add new tests.
I had to export name.encode and name.decode so they could be tested.
I want to rewrite the encoder to do name compression. This isn't a problem for queries because there's just one name but for responses, the current encoder doesn't do name compression which is recommended.