### PR TITLE
TXT data is an array of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Currently the different available records are
 }
 ```
 
-When encoding, scalar values are converted to an array and strings are converted to an UTF-8 encoded Buffer. An error is `thrown` if a string or Buffer is empty.
+When encoding, scalar values are converted to an array and strings are converted to UTF-8 encoded Buffers. An error is `thrown` if a string or Buffer is empty.
 
 When decoding, an array of Buffer is always returned.
 

--- a/README.md
+++ b/README.md
@@ -132,9 +132,14 @@ Currently the different available records are
 
 ``` js
 {
-  data: Buffer('some text')
+  data: Buffer(...)
+}
+{
+  data: 'some string'
 }
 ```
+
+Note that `data` must be an array of byte-length prefixed strings and the end of the array is signalled by a length of zero.  When encoding, a Buffer is taken as is (assumption is that it is encoded correctly), while a string is converted.
 
 #### `NS`
 

--- a/README.md
+++ b/README.md
@@ -132,14 +132,13 @@ Currently the different available records are
 
 ``` js
 {
-  data: Buffer(...)
-}
-{
-  data: 'some string'
+  data: 'text' || Buffer || [ Buffer || 'text' ]
 }
 ```
 
-Note that `data` must be an array of byte-length prefixed strings and the end of the array is signalled by a length of zero.  When encoding, a Buffer is taken as is (assumption is that it is encoded correctly), while a string is converted.
+When encoding, scalar values are converted to an array and strings are converted to an UTF-8 encoded Buffer. An error is `thrown` if a string or Buffer is empty.
+
+When decoding, an array of Buffer is always returned.
 
 #### `NS`
 

--- a/index.js
+++ b/index.js
@@ -288,11 +288,13 @@ const rtxt = exports.txt = exports.null = {}
 const rnull = rtxt
 
 rtxt.encode = function (data, buf, offset) {
-  if (!data) data = []
   if (!Array.isArray(data)) data = [data]
   for (let i = 0; i < data.length; i++) {
     if (typeof data[i] === 'string') {
       data[i] = Buffer.from(data[i])
+    }
+    if (!Buffer.isBuffer(data[i]) || data[i].length === 0) {
+      throw new Error('Must be a non-empty Buffer')
     }
   }
 
@@ -335,7 +337,6 @@ rtxt.decode = function (buf, offset) {
 rtxt.decode.bytes = 0
 
 rtxt.encodingLength = function (data) {
-  if (!data) data = []
   if (!Array.isArray(data)) data = [data]
   let length = 2 + 1
   data.forEach(function (buf) {
@@ -343,6 +344,9 @@ rtxt.encodingLength = function (data) {
       length += Buffer.byteLength(buf) + 1
     } else {
       length += buf.length + 1
+    }
+    if (length === 1) {
+      throw new Error('Must be a non-empty Buffer')
     }
   })
   return length

--- a/index.js
+++ b/index.js
@@ -284,8 +284,7 @@ rsoa.encodingLength = function (data) {
   return 22 + name.encodingLength(data.mname) + name.encodingLength(data.rname)
 }
 
-const rtxt = exports.txt = exports.null = {}
-const rnull = rtxt
+const rtxt = exports.txt = {}
 
 rtxt.encode = function (data, buf, offset) {
   if (!Array.isArray(data)) data = [data]
@@ -352,6 +351,50 @@ rtxt.encodingLength = function (data) {
     }
   })
   return length
+}
+
+const rnull = exports.null = {}
+
+rnull.encode = function (data, buf, offset) {
+  if (!buf) buf = Buffer.allocUnsafe(rnull.encodingLength(data))
+  if (!offset) offset = 0
+
+  if (typeof data === 'string') data = Buffer.from(data)
+  if (!data) data = Buffer.allocUnsafe(0)
+
+  const oldOffset = offset
+  offset += 2
+
+  const len = data.length
+  data.copy(buf, offset, 0, len)
+  offset += len
+
+  buf.writeUInt16BE(offset - oldOffset - 2, oldOffset)
+  rnull.encode.bytes = offset - oldOffset
+  return buf
+}
+
+rnull.encode.bytes = 0
+
+rnull.decode = function (buf, offset) {
+  if (!offset) offset = 0
+  const oldOffset = offset
+  const len = buf.readUInt16BE(offset)
+
+  offset += 2
+
+  const data = buf.slice(offset, offset + len)
+  offset += len
+
+  rnull.decode.bytes = offset - oldOffset
+  return data
+}
+
+rnull.decode.bytes = 0
+
+rnull.encodingLength = function (data) {
+  if (!data) return 2
+  return (Buffer.isBuffer(data) ? data.length : Buffer.byteLength(data)) + 2
 }
 
 const rhinfo = exports.hinfo = {}

--- a/index.js
+++ b/index.js
@@ -291,7 +291,14 @@ rtxt.encode = function (data, buf, offset) {
   if (!buf) buf = Buffer.allocUnsafe(rtxt.encodingLength(data))
   if (!offset) offset = 0
 
-  if (typeof data === 'string') data = Buffer.from(data)
+  if (typeof data === 'string' && data.length > 0) {
+    const s = Buffer.from(data)
+    const slen = s.length
+    data = Buffer.allocUnsafe(s.length + 2)
+    data.writeInt8(slen, 0)
+    s.copy(data, 1, 0, slen)
+    data.writeInt8(0, slen + 1)
+  }
   if (!data) data = Buffer.allocUnsafe(0)
 
   const oldOffset = offset
@@ -326,6 +333,9 @@ rtxt.decode.bytes = 0
 
 rtxt.encodingLength = function (data) {
   if (!data) return 2
+  if (typeof data === 'string') {
+    return 2 + Buffer.byteLength(data) + 2
+  }
   return (Buffer.isBuffer(data) ? data.length : Buffer.byteLength(data)) + 2
 }
 

--- a/test.js
+++ b/test.js
@@ -46,7 +46,7 @@ tape('txt-invalid-data', function (t) {
 })
 
 tape('null', function (t) {
-  testEncoder(t, packet.null, [Buffer.from([0, 1, 2, 3, 4, 5])])
+  testEncoder(t, packet.null, Buffer.from([0, 1, 2, 3, 4, 5]))
   t.end()
 })
 
@@ -201,7 +201,7 @@ tape('response', function (t) {
     answers: [{
       type: 'NULL',
       name: 'hello.null.com',
-      data: [Buffer.from([1, 2, 3, 4, 5])]
+      data: Buffer.from([1, 2, 3, 4, 5])
     }]
   })
 

--- a/test.js
+++ b/test.js
@@ -12,6 +12,7 @@ tape('unknown', function (t) {
 })
 
 tape('txt', function (t) {
+  testEncoder(t, packet.txt, [])
   testEncoder(t, packet.txt, ['hello world'])
   testEncoder(t, packet.txt, ['hello', 'world'])
   testEncoder(t, packet.txt, [Buffer.from([0, 1, 2, 3, 4, 5])])
@@ -33,6 +34,15 @@ tape('txt-scalar-buffer', function (t) {
   const val = packet.txt.decode(buf)
   t.ok(val.length === 1, 'array length')
   t.ok(val[0].equals(data), 'data')
+  t.end()
+})
+
+tape('txt-invalid-data', function (t) {
+  t.throws(function () { packet.txt.encode(null) }, 'null')
+  t.throws(function () { packet.txt.encode(undefined) }, 'undefined')
+  t.throws(function () { packet.txt.encode(10) }, 'number')
+  t.throws(function () { packet.txt.encode(Buffer.allocUnsafe(0)) }, 'empty buffer')
+  t.throws(function () { packet.txt.encode('') }, 'empty string')
   t.end()
 })
 

--- a/test.js
+++ b/test.js
@@ -17,6 +17,7 @@ tape('txt', function (t) {
   testEncoder(t, packet.txt, ['hello', 'world'])
   testEncoder(t, packet.txt, [Buffer.from([0, 1, 2, 3, 4, 5])])
   testEncoder(t, packet.txt, ['a', 'b', Buffer.from([0, 1, 2, 3, 4, 5])])
+  testEncoder(t, packet.txt, ['', Buffer.allocUnsafe(0)])
   t.end()
 })
 
@@ -41,8 +42,6 @@ tape('txt-invalid-data', function (t) {
   t.throws(function () { packet.txt.encode(null) }, 'null')
   t.throws(function () { packet.txt.encode(undefined) }, 'undefined')
   t.throws(function () { packet.txt.encode(10) }, 'number')
-  t.throws(function () { packet.txt.encode(Buffer.allocUnsafe(0)) }, 'empty buffer')
-  t.throws(function () { packet.txt.encode('') }, 'empty string')
   t.end()
 })
 

--- a/test.js
+++ b/test.js
@@ -12,23 +12,32 @@ tape('unknown', function (t) {
 })
 
 tape('txt', function (t) {
-  testEncoder(t, packet.txt, Buffer.allocUnsafe(0))
-  testEncoder(t, packet.txt, Buffer.from('hello world'))
-  testEncoder(t, packet.txt, Buffer.from([0, 1, 2, 3, 4, 5]))
+  testEncoder(t, packet.txt, ['hello world'])
+  testEncoder(t, packet.txt, ['hello', 'world'])
+  testEncoder(t, packet.txt, [Buffer.from([0, 1, 2, 3, 4, 5])])
+  testEncoder(t, packet.txt, ['a', 'b', Buffer.from([0, 1, 2, 3, 4, 5])])
   t.end()
 })
 
-tape('txt-string', function (t) {
+tape('txt-scalar-string', function (t) {
   const buf = packet.txt.encode('hi')
   const val = packet.txt.decode(buf)
-  t.ok(val[0] === 2, 'length prefix')
-  t.ok(val.toString('utf8', 1, 3) === 'hi', 'data')
-  t.ok(val[3] === 0, 'end of array')
+  t.ok(val.length === 1, 'array length')
+  t.ok(val[0].toString() === 'hi', 'data')
+  t.end()
+})
+
+tape('txt-scalar-buffer', function (t) {
+  const data = Buffer.from([0, 1, 2, 3, 4, 5])
+  const buf = packet.txt.encode(data)
+  const val = packet.txt.decode(buf)
+  t.ok(val.length === 1, 'array length')
+  t.ok(val[0].equals(data), 'data')
   t.end()
 })
 
 tape('null', function (t) {
-  testEncoder(t, packet.null, Buffer.from([0, 1, 2, 3, 4, 5]))
+  testEncoder(t, packet.null, [Buffer.from([0, 1, 2, 3, 4, 5])])
   t.end()
 })
 
@@ -183,7 +192,7 @@ tape('response', function (t) {
     answers: [{
       type: 'NULL',
       name: 'hello.null.com',
-      data: Buffer.from([1, 2, 3, 4, 5])
+      data: [Buffer.from([1, 2, 3, 4, 5])]
     }]
   })
 

--- a/test.js
+++ b/test.js
@@ -18,6 +18,15 @@ tape('txt', function (t) {
   t.end()
 })
 
+tape('txt-string', function (t) {
+  const buf = packet.txt.encode('hi')
+  const val = packet.txt.decode(buf)
+  t.ok(val[0] === 2, 'length prefix')
+  t.ok(val.toString('utf8', 1, 3) === 'hi', 'data')
+  t.ok(val[3] === 0, 'end of array')
+  t.end()
+})
+
 tape('null', function (t) {
   testEncoder(t, packet.null, Buffer.from([0, 1, 2, 3, 4, 5]))
   t.end()


### PR DESCRIPTION
Fix writing a string to a TXT record; see issue https://github.com/mafintosh/dns-packet/issues/25.

This is a **breaking change** in that receivers of the TXT will have to process the `rtxt.data` differently.  However, if they received the record from a DNS that does not use this package, then they already have this issue.

Perhaps `rtxt.data` should always be an array?
