### PR TITLE
Flush bit and class

### DIFF
--- a/index.js
+++ b/index.js
@@ -680,11 +680,11 @@ answer.decode = function (buf, offset) {
   a.name = name.decode(buf, offset)
   offset += name.decode.bytes
   a.type = types.toString(buf.readUInt16BE(offset))
-  a.class = classes.toString(buf.readUInt16BE(offset + 2))
+  const klass = buf.readUInt16BE(offset + 2)
   a.ttl = buf.readUInt32BE(offset + 4)
 
-  a.flush = !!(a.class & FLUSH_MASK)
-  if (a.flush) a.class &= NOT_FLUSH_MASK
+  a.class = classes.toString(klass & NOT_FLUSH_MASK)
+  a.flush = !!(klass & FLUSH_MASK)
 
   const enc = renc(a.type)
   a.data = enc.decode(buf, offset + 8)

--- a/test.js
+++ b/test.js
@@ -155,6 +155,17 @@ tape('query', function (t) {
 tape('response', function (t) {
   testEncoder(t, packet, {
     type: 'response',
+    answers: [{
+      type: 'A',
+      class: 'IN',
+      flush: true,
+      name: 'hello.a.com',
+      data: '127.0.0.1'
+    }]
+  })
+
+  testEncoder(t, packet, {
+    type: 'response',
     flags: packet.TRUNCATED_RESPONSE,
     answers: [{
       type: 'A',


### PR DESCRIPTION
In a response, when the flush bit is set the class was always `Unknown_xxx'.

Need to mask the class bits before converting to a string.