### PR TITLE
Add EDNS(0) OPT RR for UDP payload size in query.

### DIFF
--- a/test.js
+++ b/test.js
@@ -321,6 +321,28 @@ tape('stream', function (t) {
   t.end()
 })
 
+tape('opt', function (t) {
+  const val = {
+    type: 'query',
+    questions: [{
+      type: 'A',
+      name: 'hello.a.com'
+    }],
+    additionals: [{
+      type: 'OPT',
+      name: '.',
+      udp: 4096
+    }]
+  }
+  testEncoder(t, packet, val)
+  const buf = packet.encode(val)
+  const val2 = packet.decode(buf)
+  const additional1 = val.additionals[0]
+  const additional2 = val2.additionals[0]
+  t.ok(compare(t, additional1.udp, additional2.udp), 'udp payload size matches')
+  t.end()
+})
+
 tape('unpack', function (t) {
   const buf = Buffer.from([
     0x00, 0x79,


### PR DESCRIPTION
This adds support for indicating to the server that the client accepts responses larger than 512 octets over UDP by adding an additional record to the query with the UDP payload size:
```
{
  type: 'query',
  id: 1234,
  flags: packet.RECURSION_DESIRED,
  questions: [{
    type: 'A',
    name: 'google.com'
  }],
  additionals: [{
    type: 'OPT',
    name: '.',
    udp: 4096
  }]
}
```
The **udp** field is optional. The size defaults to 4096 if the 'OPT' resource record is present. Currently, the name MUST be specified and it must be '.' (root).

This also fixes a bug with the name encoding length of '.' (root). Previously, it always added 2 to the string length but this is incorrect for the case of root because it is encoded as a single 0x00.

This code does not yet support processing of EDNS(0) options. Those will be added in the future.