### PR TITLE
Remove accidental or in typebitmap.encodingLength

### DIFF
--- a/index.js
+++ b/index.js
@@ -944,7 +944,7 @@ typebitmap.encodingLength = function (typelist) {
   var extents = []
   for (var i = 0; i < typelist.length; i++) {
     var typeid = types.toType(typelist[i])
-    extents[typeid >> 8] |= Math.max(extents[typeid >> 8] || 0, typeid & 0xFF)
+    extents[typeid >> 8] = Math.max(extents[typeid >> 8] || 0, typeid & 0xFF)
   }
 
   var len = 0

--- a/test.js
+++ b/test.js
@@ -404,6 +404,26 @@ tape('nsec', function (t) {
     nextDomain: 'foo.com',
     rrtypes: ['A', 'DNSKEY', 'CAA', 'DLV']
   })
+  testEncoder(t, packet.nsec, {
+    nextDomain: 'foo.com',
+    rrtypes: ['TXT'] // 16
+  })
+  testEncoder(t, packet.nsec, {
+    nextDomain: 'foo.com',
+    rrtypes: ['TKEY'] // 249
+  })
+  testEncoder(t, packet.nsec, {
+    nextDomain: 'foo.com',
+    rrtypes: ['RRSIG', 'NSEC']
+  })
+  testEncoder(t, packet.nsec, {
+    nextDomain: 'foo.com',
+    rrtypes: ['TXT', 'RRSIG']
+  })
+  testEncoder(t, packet.nsec, {
+    nextDomain: 'foo.com',
+    rrtypes: ['TXT', 'NSEC']
+  })
 
   // Test with the sample NSEC from https://tools.ietf.org/html/rfc4034#section-4.3
   var sampleNSEC = Buffer.from('003704686f7374076578616d706c6503636f6d00' +


### PR DESCRIPTION
This lead to sometimes incorrectly calculating the size of type bitmaps that contained multiple values in a window.