### PR TITLE
add support for encoding RP records

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,14 @@ And an answers, additional, or authority looks like this
 }
 ```
 
+#### `RP`
+
+``` js
+{
+  data: mbox-dname
+}
+```
+
 #### `SOA`
 
 ``` js

--- a/README.md
+++ b/README.md
@@ -293,7 +293,8 @@ And an answers, additional, or authority looks like this
 
 ``` js
 {
-  data: mbox-dname
+  mbox: mbox-dname,
+  txt: txt-dname
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -881,12 +881,15 @@ rrrsig.encodingLength = function (sig) {
 const rrp = exports.rp = {}
 
 rrp.encode = function (data, buf, offset) {
+  data.txt = data.txt || '.'
   if (!buf) buf = Buffer.allocUnsafe(rrp.encodingLength(data))
   if (!offset) offset = 0
 
-  name.encode(data, buf, offset + 2)
-  buf.writeUInt16BE(name.encode.bytes, offset)
-  rrp.encode.bytes = name.encode.bytes + 2
+  string.encode(data.mbox, buf, offset)
+  offset += string.encode.bytes
+  string.encode(data.txt, buf, offset)
+
+  rrp.encode.bytes = rrp.encodingLength(data)
   return buf
 }
 
@@ -895,17 +898,22 @@ rrp.encode.bytes = 0
 rrp.decode = function (buf, offset) {
   if (!offset) offset = 0
 
-  const len = buf.readUInt16BE(offset)
-  const dd = name.decode(buf, offset + 2)
+  const oldOffset = offset
 
-  rrp.decode.bytes = len + 2
-  return dd
+  const data = {}
+  data.mbox = string.decode(buf, offset)
+  offset += string.decode.bytes
+  data.txt = string.decode(buf, offset)
+  offset += string.decode.bytes
+
+  rrp.decode.bytes = offset - oldOffset
+  return data
 }
 
 rrp.decode.bytes = 0
 
 rrp.encodingLength = function (data) {
-  return name.encodingLength(data) + 2
+  return string.encodingLength(data.mbox || data) + string.encodingLength(data.txt || '.') + 2
 }
 
 const typebitmap = {}

--- a/index.js
+++ b/index.js
@@ -878,6 +878,36 @@ rrrsig.encodingLength = function (sig) {
     Buffer.byteLength(sig.signature)
 }
 
+const rrp = exports.rp = {}
+
+rrp.encode = function (data, buf, offset) {
+  if (!buf) buf = Buffer.allocUnsafe(rrp.encodingLength(data))
+  if (!offset) offset = 0
+
+  name.encode(data, buf, offset + 2)
+  buf.writeUInt16BE(name.encode.bytes, offset)
+  rrp.encode.bytes = name.encode.bytes + 2
+  return buf
+}
+
+rrp.encode.bytes = 0
+
+rrp.decode = function (buf, offset) {
+  if (!offset) offset = 0
+
+  const len = buf.readUInt16BE(offset)
+  const dd = name.decode(buf, offset + 2)
+
+  rrp.decode.bytes = len + 2
+  return dd
+}
+
+rrp.decode.bytes = 0
+
+rrp.encodingLength = function (data) {
+  return name.encodingLength(data) + 2
+}
+
 const typebitmap = {}
 
 typebitmap.encode = function (typelist, buf, offset) {
@@ -1152,6 +1182,7 @@ const renc = exports.record = function (type) {
     case 'OPT': return ropt
     case 'DNSKEY': return rdnskey
     case 'RRSIG': return rrrsig
+    case 'RP': return rrp
     case 'NSEC': return rnsec
     case 'NSEC3': return rnsec3
     case 'DS': return rds

--- a/test.js
+++ b/test.js
@@ -400,7 +400,13 @@ tape('rrsig', function (t) {
 })
 
 tape('rrp', function (t) {
-  testEncoder(t, packet.rp, 'rp.world.com')
+  testEncoder(t, packet.rp, {
+    mbox: 'rp.world.com',
+    txt: 'hello'
+  })
+  testEncoder(t, packet.rp, {
+    mbox: 'rp.world.com'
+  })
   t.end()
 })
 

--- a/test.js
+++ b/test.js
@@ -399,6 +399,11 @@ tape('rrsig', function (t) {
   t.end()
 })
 
+tape('rrp', function (t) {
+  testEncoder(t, packet.rp, 'rp.world.com')
+  t.end()
+})
+
 tape('nsec', function (t) {
   testEncoder(t, packet.nsec, {
     nextDomain: 'foo.com',


### PR DESCRIPTION
this implementation makes encoding `RP` records possible, very similar to how `NS` records are encoded (the encoding for `NS` was copy/pasted for `RP` 🙂 )

if you could kindly review this in conjunction with [the spec for RP record](http://www.rfc-editor.org/rfc/rfc1183.txt) and then make a decision, that will be great...

and, thank you for the work on this and other related awesome libraries... :)