### PR TITLE
Fix udpPayloadSize encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -1316,7 +1316,7 @@ answer.encode = function (a, buf, offset) {
     if (a.name !== '.') {
       throw new Error('OPT name must be root.')
     }
-    buf.writeUInt16BE(a.updPayloadSize || 4096, offset + 2)
+    buf.writeUInt16BE(a.udpPayloadSize || 4096, offset + 2)
     buf.writeUInt8(a.extendedRcode || 0, offset + 4)
     buf.writeUInt8(a.ednsVersion || 0, offset + 5)
     buf.writeUInt16BE(a.flags || 0, offset + 6)

--- a/test.js
+++ b/test.js
@@ -340,7 +340,7 @@ tape('opt', function (t) {
     additionals: [{
       type: 'OPT',
       name: '.',
-      udpPayloadSize: 4096
+      udpPayloadSize: 1024
     }]
   }
   testEncoder(t, packet, val)


### PR DESCRIPTION
Fixed a typo in the code which caused `udpPayloadSize` option to be ignored. Tests didn't catch this because the tested value 4096 is also used as a default, so I updated the tests as well to use a non-default value.