### PR TITLE
Wrong `name.encodingLength()` for `""` and `"example.com."` -> extra, trailing byte

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ name.decode = function (buf, offset) {
 name.decode.bytes = 0
 
 name.encodingLength = function (n) {
-  if (n === '.') return 1
+  if (n === '.' || n === '') return 1
   return Buffer.byteLength(n) + 2
 }
 


### PR DESCRIPTION
`name.encodingLength()` returns the wrong length (off by one) for `""` (empty string) and `"example.com."` (absolute, ends in a dot) whereas `name.encode()` correctly handles both. Is this by design?

`name.encodingLength()` handles `"example.com"` (doesn't end in a dot) but not `""`, and `"."` (dot) but not `"example.com."`. `name.encode()` handles all four cases. The upshot is that `answer.encode({ name: "", type: "A", data: "1.2.3.4" })` returns one extra, trailing byte. I've only ever observed it return a zero byte, but I guess it could be *anything*, because it uses [`Buffer.allocUnsafe()`](https://nodejs.org/api/buffer.html#buffer_class_method_buffer_allocunsafe_size)?

This simple commit just adds `""` to the cases that `name.encodingLength()` supports. I'm happy to fix the `"example.com."` case in the same commit, if I'm on the right track?