### PR TITLE
update doh (and dot) examples

### DIFF
--- a/examples/doh.js
+++ b/examples/doh.js
@@ -26,13 +26,12 @@ const buf = dnsPacket.encode({
 })
 
 const options = {
-  hostname: 'dns.google.com',
+  hostname: 'dns.google',
   port: 443,
-  path: '/experimental',
+  path: '/dns-query',
   method: 'POST',
   headers: {
-    'Content-Type': 'application/dns-udpwireformat',
-    'Content-Length': Buffer.byteLength(buf)
+    'Content-Type': 'application/dns-message',
   }
 }
 

--- a/examples/tls.js
+++ b/examples/tls.js
@@ -26,7 +26,7 @@ const context = tls.createSecureContext({
 
 const options = {
   port: 853,
-  host: 'getdnsapi.net',
+  host: '1.1.1.1',
   secureContext: context
 }
 


### PR DESCRIPTION
- Updated broken `examples/doh.js` to match Google's current API (see https://developers.google.com/speed/public-dns/docs/doh for details)
- Switched out getdnsapi.net for 1.1.1.1 (Cloudflare) in `examples/tls.js`. getdnsapi.net resolves to 185.49.141.37, and it looks like an authoritative server (it also appears to not support DNS over TLS).