### PR TITLE
Mark flush in the questions part from MSB of class value

### DIFF
--- a/index.js
+++ b/index.js
@@ -1417,7 +1417,9 @@ question.decode = function (buf, offset) {
   q.type = types.toString(buf.readUInt16BE(offset))
   offset += 2
 
-  q.class = classes.toString(buf.readUInt16BE(offset))
+  const klass = buf.readUInt16BE(offset)
+  q.class = classes.toString(klass & NOT_FLUSH_MASK)
+  q.flush = !!(klass & FLUSH_MASK)
   offset += 2
 
   const qu = !!(q.class & QU_MASK)


### PR DESCRIPTION
I found many mdns query packets have cache-flush bit set. But when those packets are received, they spoil questions part as wrong class value, while the cache-flush bit in answer part is well treated with 'flush' value of result object.

I added flush marking part to questions part, which is copied from anwer decoding part.