### PR TITLE
Add constant for NXDOMAIN

### DIFF
--- a/index.js
+++ b/index.js
@@ -1440,6 +1440,7 @@ exports.RECURSION_AVAILABLE = 1 << 7
 exports.AUTHENTIC_DATA = 1 << 5
 exports.CHECKING_DISABLED = 1 << 4
 exports.DNSSEC_OK = 1 << 15
+exports.NXDOMAIN = 0x03
 
 exports.encode = function (result, buf, offset) {
   if (!buf) buf = Buffer.allocUnsafe(exports.encodingLength(result))


### PR DESCRIPTION
Trivially OR'ing 0x03 to the flags works to set NXDOMAIN in the response header. Exposing a constant for this makes it accessible and obvious.