### PR TITLE
Replacing ip with @leichtgewicht/ip-codec

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "coverage": "nyc -r html npm test"
   },
   "dependencies": {
-    "ip": "^1.1.5"
+    "@leichtgewicht/ip-codec": "^2.0.1"
   },
   "devDependencies": {
     "eslint": "^5.14.1",


### PR DESCRIPTION
The `ip` npm package references both `buffer` and `os` which makes it kind of stressful to use in a browser setting. This PR uses the extracted  encoding functionality of `node-ip` through  [@leichtgewicht/ip-codec](https://github.com/martinheidegger/ip-codec). Reducing a bit of performance overhead in the process.