### PR TITLE
fix: explicit Buffer reference for webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const Buffer = require('buffer').Buffer
 const types = require('./types')
 const rcodes = require('./rcodes')
 const opcodes = require('./opcodes')


### PR DESCRIPTION
Without using a `require('buffer')` statement webpack has a hard time to make sure it works in the browser.