### PR TITLE
Make name.decode stricter

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,9 @@ name.decode = function (buf, offset) {
   let jumped = false
 
   while (true) {
+    if (offset >= buf.length) {
+      throw new Error('Can\'t decode name (buffer overflow)')
+    }
     const len = buf[offset++]
     consumedBytes += jumped ? 0 : 1
 

--- a/index.js
+++ b/index.js
@@ -42,37 +42,52 @@ name.encode = function (str, buf, offset) {
 
 name.encode.bytes = 0
 
+function decodeName (buf, offset, list, totalLength) {
+  const oldOffset = offset
+  let len = buf[offset++]
+
+  while (len > 0) {
+    if ((len & 0xc0) === 0xc0) {
+      if (offset + 1 > buf.length) {
+        throw new Error('Can\'t decode name (buffer overflow)')
+      }
+      const jumpOffset = buf.readUInt16BE(offset - 1) - 0xc000
+      if (jumpOffset >= oldOffset) {
+        // Allow only pointers to prior data. RFC 1035, section 4.1.4 states:
+        // "[...] an entire domain name or a list of labels at the end of a domain name
+        // is replaced with a pointer to a prior occurance (sic) of the same name."
+        throw new Error('Can\'t decode name (bad pointer)')
+      }
+      decodeName(buf, jumpOffset, list, totalLength)
+      offset++
+      break
+    } else if ((len & 0xc0) === 0) {
+      if (offset + len > buf.length) {
+        throw new Error('Can\'t decode name (buffer overflow)')
+      }
+      totalLength += len + 1
+      if (totalLength > 254) {
+        throw new Error('Can\'t decode name (name too long)')
+      }
+      list.push(buf.toString('utf-8', offset, offset + len))
+      offset += len
+      len = buf[offset++]
+    } else {
+      throw new Error('Can\'t decode name (bad label)')
+    }
+  }
+
+  return offset
+}
+
 name.decode = function (buf, offset) {
   if (!offset) offset = 0
 
   const list = []
-  const oldOffset = offset
-  let len = buf[offset++]
+  const newOffset = decodeName(buf, offset, list, 0)
 
-  if (len === 0) {
-    name.decode.bytes = 1
-    return '.'
-  }
-  if (len >= 0xc0) {
-    const res = name.decode(buf, buf.readUInt16BE(offset - 1) - 0xc000)
-    name.decode.bytes = 2
-    return res
-  }
-
-  while (len) {
-    if (len >= 0xc0) {
-      list.push(name.decode(buf, buf.readUInt16BE(offset - 1) - 0xc000))
-      offset++
-      break
-    }
-
-    list.push(buf.toString('utf-8', offset, offset + len))
-    offset += len
-    len = buf[offset++]
-  }
-
-  name.decode.bytes = offset - oldOffset
-  return list.join('.')
+  name.decode.bytes = newOffset - offset
+  return list.length === 0 ? '.' : list.join('.')
 }
 
 name.decode.bytes = 0

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ name.decode = function (buf, offset) {
 
   while (true) {
     if (offset >= buf.length) {
-      throw new Error('Can\'t decode name (buffer overflow)')
+      throw new Error('Cannot decode name (buffer overflow)')
     }
     const len = buf[offset++]
     consumedBytes += jumped ? 0 : 1
@@ -62,32 +62,32 @@ name.decode = function (buf, offset) {
       break
     } else if ((len & 0xc0) === 0) {
       if (offset + len > buf.length) {
-        throw new Error('Can\'t decode name (buffer overflow)')
+        throw new Error('Cannot decode name (buffer overflow)')
       }
       totalLength += len + 1
       if (totalLength > 254) {
-        throw new Error('Can\'t decode name (name too long)')
+        throw new Error('Cannot decode name (name too long)')
       }
       list.push(buf.toString('utf-8', offset, offset + len))
       offset += len
       consumedBytes += jumped ? 0 : len
     } else if ((len & 0xc0) === 0xc0) {
       if (offset + 1 > buf.length) {
-        throw new Error('Can\'t decode name (buffer overflow)')
+        throw new Error('Cannot decode name (buffer overflow)')
       }
       const jumpOffset = buf.readUInt16BE(offset - 1) - 0xc000
       if (jumpOffset >= oldOffset) {
         // Allow only pointers to prior data. RFC 1035, section 4.1.4 states:
         // "[...] an entire domain name or a list of labels at the end of a domain name
         // is replaced with a pointer to a prior occurance (sic) of the same name."
-        throw new Error('Can\'t decode name (bad pointer)')
+        throw new Error('Cannot decode name (bad pointer)')
       }
       offset = jumpOffset
       oldOffset = jumpOffset
       consumedBytes += jumped ? 0 : 1
       jumped = true
     } else {
-      throw new Error('Can\'t decode name (bad label)')
+      throw new Error('Cannot decode name (bad label)')
     }
   }
 

--- a/test.js
+++ b/test.js
@@ -336,6 +336,13 @@ tape('name_decoding', function (t) {
   // Ensure a jump to a null byte doesn't add extra dots
   t.ok(packet.name.decode(Buffer.from([0x00, 0x01, 0x61, 0xc0, 0x00]), 1) === 'a')
 
+  // Ensure deeply nested pointers don't cause "Maximum call stack size exceeded" errors
+  const buf = Buffer.alloc(16386)
+  for (let i = 0; i < 16384; i += 2) {
+    buf.writeUInt16BE(0xc000 | i, i + 2)
+  }
+  t.ok(packet.name.decode(buf, 16384) === '.')
+
   t.end()
 })
 

--- a/test.js
+++ b/test.js
@@ -306,18 +306,18 @@ tape('name_encoding', function (t) {
 
 tape('name_decoding', function (t) {
   // The two most significant bits of a valid label header must be either both zero or both one
-  t.throws(function () { packet.name.decode(Buffer.from([0x80])) }, /Can't decode name \(bad label\)$/)
-  t.throws(function () { packet.name.decode(Buffer.from([0xb0])) }, /Can't decode name \(bad label\)$/)
+  t.throws(function () { packet.name.decode(Buffer.from([0x80])) }, /Cannot decode name \(bad label\)$/)
+  t.throws(function () { packet.name.decode(Buffer.from([0xb0])) }, /Cannot decode name \(bad label\)$/)
 
   // Ensure there's enough buffer to read
-  t.throws(function () { packet.name.decode(Buffer.from([])) }, /Can't decode name \(buffer overflow\)$/)
-  t.throws(function () { packet.name.decode(Buffer.from([0x01, 0x00])) }, /Can't decode name \(buffer overflow\)$/)  
-  t.throws(function () { packet.name.decode(Buffer.from([0x01])) }, /Can't decode name \(buffer overflow\)$/)
-  t.throws(function () { packet.name.decode(Buffer.from([0xc0])) }, /Can't decode name \(buffer overflow\)$/)
+  t.throws(function () { packet.name.decode(Buffer.from([])) }, /Cannot decode name \(buffer overflow\)$/)
+  t.throws(function () { packet.name.decode(Buffer.from([0x01, 0x00])) }, /Cannot decode name \(buffer overflow\)$/)
+  t.throws(function () { packet.name.decode(Buffer.from([0x01])) }, /Cannot decode name \(buffer overflow\)$/)
+  t.throws(function () { packet.name.decode(Buffer.from([0xc0])) }, /Cannot decode name \(buffer overflow\)$/)
 
   // Allow only pointers backwards
-  t.throws(function () { packet.name.decode(Buffer.from([0xc0, 0x00])) }, /Can't decode name \(bad pointer\)$/)
-  t.throws(function () { packet.name.decode(Buffer.from([0xc0, 0x01])) }, /Can't decode name \(bad pointer\)$/)
+  t.throws(function () { packet.name.decode(Buffer.from([0xc0, 0x00])) }, /Cannot decode name \(bad pointer\)$/)
+  t.throws(function () { packet.name.decode(Buffer.from([0xc0, 0x01])) }, /Cannot decode name \(bad pointer\)$/)
 
   // A name can be only 253 characters (when connected with dots)
   const maxLength = Buffer.alloc(255)
@@ -326,14 +326,14 @@ tape('name_decoding', function (t) {
 
   const tooLong = Buffer.alloc(256)
   tooLong.fill(Buffer.from([0x01, 0x61]))
-  t.throws(function () { packet.name.decode(tooLong) }, /Can't decode name \(name too long\)$/)
+  t.throws(function () { packet.name.decode(tooLong) }, /Cannot decode name \(name too long\)$/)
 
   // Ensure jumps don't reset the total length counter
   const tooLongWithJump = Buffer.alloc(403)
   tooLongWithJump.fill(Buffer.from([0x01, 0x61]), 0, 200)
   tooLongWithJump.fill(Buffer.from([0x01, 0x61]), 201, 401)
   tooLongWithJump.set([0xc0, 0x00], 401)
-  t.throws(function () { packet.name.decode(tooLongWithJump, 201) }, /Can't decode name \(name too long\)$/)
+  t.throws(function () { packet.name.decode(tooLongWithJump, 201) }, /Cannot decode name \(name too long\)$/)
 
   // Ensure a jump to a null byte doesn't add extra dots
   t.ok(packet.name.decode(Buffer.from([0x00, 0x01, 0x61, 0xc0, 0x00]), 1) === 'a')

--- a/test.js
+++ b/test.js
@@ -310,6 +310,8 @@ tape('name_decoding', function (t) {
   t.throws(function () { packet.name.decode(Buffer.from([0xb0])) }, /Can't decode name \(bad label\)$/)
 
   // Ensure there's enough buffer to read
+  t.throws(function () { packet.name.decode(Buffer.from([])) }, /Can't decode name \(buffer overflow\)$/)
+  t.throws(function () { packet.name.decode(Buffer.from([0x01, 0x00])) }, /Can't decode name \(buffer overflow\)$/)  
   t.throws(function () { packet.name.decode(Buffer.from([0x01])) }, /Can't decode name \(buffer overflow\)$/)
   t.throws(function () { packet.name.decode(Buffer.from([0xc0])) }, /Can't decode name \(buffer overflow\)$/)
 

--- a/test.js
+++ b/test.js
@@ -306,16 +306,16 @@ tape('name_encoding', function (t) {
 
 tape('name_decoding', function (t) {
   // The two most significant bits of a valid label header must be either both zero or both one
-  t.throws(function () { packet.name.decode(Buffer.from([0x80])) })
-  t.throws(function () { packet.name.decode(Buffer.from([0xb0])) })
+  t.throws(function () { packet.name.decode(Buffer.from([0x80])) }, /Can't decode name \(bad label\)$/)
+  t.throws(function () { packet.name.decode(Buffer.from([0xb0])) }, /Can't decode name \(bad label\)$/)
 
   // Ensure there's enough buffer to read
-  t.throws(function () { packet.name.decode(Buffer.from([0x01])) })
-  t.throws(function () { packet.name.decode(Buffer.from([0xc0])) })
+  t.throws(function () { packet.name.decode(Buffer.from([0x01])) }, /Can't decode name \(buffer overflow\)$/)
+  t.throws(function () { packet.name.decode(Buffer.from([0xc0])) }, /Can't decode name \(buffer overflow\)$/)
 
-  // Allow only jumping backwards
-  t.throws(function () { packet.name.decode(Buffer.from([0xc0, 0x00])) })
-  t.throws(function () { packet.name.decode(Buffer.from([0xc0, 0x01])) })
+  // Allow only pointers backwards
+  t.throws(function () { packet.name.decode(Buffer.from([0xc0, 0x00])) }, /Can't decode name \(bad pointer\)$/)
+  t.throws(function () { packet.name.decode(Buffer.from([0xc0, 0x01])) }, /Can't decode name \(bad pointer\)$/)
 
   // A name can be only 253 characters (when connected with dots)
   const maxLength = Buffer.alloc(255)
@@ -324,16 +324,16 @@ tape('name_decoding', function (t) {
 
   const tooLong = Buffer.alloc(256)
   tooLong.fill(Buffer.from([0x01, 0x61]))
-  t.throws(function () { packet.name.decode(tooLong) })
+  t.throws(function () { packet.name.decode(tooLong) }, /Can't decode name \(name too long\)$/)
 
   // Ensure jumps don't reset the total length counter
   const tooLongWithJump = Buffer.alloc(403)
   tooLongWithJump.fill(Buffer.from([0x01, 0x61]), 0, 200)
   tooLongWithJump.fill(Buffer.from([0x01, 0x61]), 201, 401)
   tooLongWithJump.set([0xc0, 0x00], 401)
-  t.throws(function () { packet.name.decode(tooLongWithJump, 201) })
+  t.throws(function () { packet.name.decode(tooLongWithJump, 201) }, /Can't decode name \(name too long\)$/)
 
-  // Ensure a jump to a null byte doesn't add an extra dot
+  // Ensure a jump to a null byte doesn't add extra dots
   t.ok(packet.name.decode(Buffer.from([0x00, 0x01, 0x61, 0xc0, 0x00]), 1) === 'a')
 
   t.end()


### PR DESCRIPTION
This pull request makes the `name.decode` function to be stricter about what kind of data it accepts:

 * Check that there's enough packet data to read before each step (reading the label header, reading label data, pointer decoding). Raise an error when there's not enough packet data.
 * Ensure that the maximum total name length is 253 (when counting the separator dots). Raise an error when it seems like the name will be longer.
 * The two most significant bits of label headers bytes must either be both set or be both unset. Raise an error when encountering a label header byte that doesn't adhere to this rule.
   * This also effectively limits the length of a single label to 63 bytes.
 * Require pointers to always point to _prior_ data (based on a reading of [RFC 1035, section 4.1.4](https://datatracker.ietf.org/doc/html/rfc1035#section-4.1.4)). Raise an error when a pointer doesn't adhere to this rule.
   * This helps avoiding infinite pointer loops (example: https://rustsec.org/advisories/RUSTSEC-2018-0007.html).
 * Fix a corner case where a valid compressed name got suffixed with two extra dots.
 * Make the whole function non-recursive.

This pull request also adds tests aimed to catch these cases.

Without to these checks it's possible to craft packets that take advantage of `name.decode` to cause Node.js to run out of memory when processing a ~60 kilobyte packet that takes advantage of infinite pointer loops and unlimited name lengths:

```js
const packet = require("dns-packet");

const buf = Buffer.alloc(65500);
buf.set([
  0xbe, 0xef, 0x85, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
]);
buf.fill(Buffer.from([0x01, 0x00]), 12);
buf.writeUInt16BE(0xc00c, buf.length - 2);

packet.decode(buf);
```

Just for full disclosure: Prior to making this pull request I confirmed from @mafintosh over Twitter DMs whether it's okay to submit this PR publicly 🙂