### PR TITLE
Proper Encoding/Decoding for Email Name Representation for SOA and RP Records

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const NOT_QU_MASK = ~QU_MASK
 
 const name = exports.name = {}
 
-name.encode = function (str, buf, offset) {
+name.encode = function (str, buf, offset, mail = false) {
   if (!buf) buf = Buffer.alloc(name.encodingLength(str))
   if (!offset) offset = 0
   const oldOffset = offset
@@ -25,7 +25,23 @@ name.encode = function (str, buf, offset) {
   // strip leading and trailing .
   const n = str.replace(/^\.|\.$/gm, '')
   if (n.length) {
-    const list = n.split('.')
+    let list = []
+    if (mail) {
+      let localPart = ''
+      n.split('.').forEach(label => {
+        if (label.endsWith('\\')) {
+          localPart += (localPart.length ? '.' : '') + label.slice(0, -1)
+        } else {
+          if (list.length === 0 && localPart.length) {
+            list.push(localPart + '.' + label)
+          } else {
+            list.push(label)
+          }
+        }
+      })
+    } else {
+      list = n.split('.')
+    }
 
     for (let i = 0; i < list.length; i++) {
       const len = buf.write(list[i], offset + 1)
@@ -42,7 +58,7 @@ name.encode = function (str, buf, offset) {
 
 name.encode.bytes = 0
 
-name.decode = function (buf, offset) {
+name.decode = function (buf, offset, mail = false) {
   if (!offset) offset = 0
 
   const list = []
@@ -68,7 +84,11 @@ name.decode = function (buf, offset) {
       if (totalLength > 254) {
         throw new Error('Cannot decode name (name too long)')
       }
-      list.push(buf.toString('utf-8', offset, offset + len))
+      if (mail) {
+        list.push(buf.toString('utf-8', offset, offset + len).replace(/\./g, '\\.'))
+      } else {
+        list.push(buf.toString('utf-8', offset, offset + len))
+      }
       offset += len
       consumedBytes += jumped ? 0 : len
     } else if ((len & 0xc0) === 0xc0) {
@@ -254,7 +274,7 @@ rsoa.encode = function (data, buf, offset) {
   offset += 2
   name.encode(data.mname, buf, offset)
   offset += name.encode.bytes
-  name.encode(data.rname, buf, offset)
+  name.encode(data.rname, buf, offset, true)
   offset += name.encode.bytes
   buf.writeUInt32BE(data.serial || 0, offset)
   offset += 4
@@ -283,7 +303,7 @@ rsoa.decode = function (buf, offset) {
   offset += 2
   data.mname = name.decode(buf, offset)
   offset += name.decode.bytes
-  data.rname = name.decode(buf, offset)
+  data.rname = name.decode(buf, offset, true)
   offset += name.decode.bytes
   data.serial = buf.readUInt32BE(offset)
   offset += 4
@@ -1007,7 +1027,7 @@ rrp.encode = function (data, buf, offset) {
   const oldOffset = offset
 
   offset += 2 // Leave space for length
-  name.encode(data.mbox || '.', buf, offset)
+  name.encode(data.mbox || '.', buf, offset, true)
   offset += name.encode.bytes
   name.encode(data.txt || '.', buf, offset)
   offset += name.encode.bytes
@@ -1024,7 +1044,7 @@ rrp.decode = function (buf, offset) {
 
   const data = {}
   offset += 2
-  data.mbox = name.decode(buf, offset) || '.'
+  data.mbox = name.decode(buf, offset, true) || '.'
   offset += name.decode.bytes
   data.txt = name.decode(buf, offset) || '.'
   offset += name.decode.bytes

--- a/index.js
+++ b/index.js
@@ -84,11 +84,11 @@ name.decode = function (buf, offset, { mail = false } = {}) {
       if (totalLength > 254) {
         throw new Error('Cannot decode name (name too long)')
       }
+      let label = buf.toString('utf-8', offset, offset + len)
       if (mail) {
-        list.push(buf.toString('utf-8', offset, offset + len).replace(/\./g, '\\.'))
-      } else {
-        list.push(buf.toString('utf-8', offset, offset + len))
+        label = label.replace(/\./g, '\\.')
       }
+      list.push(label)
       offset += len
       consumedBytes += jumped ? 0 : len
     } else if ((len & 0xc0) === 0xc0) {

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const NOT_QU_MASK = ~QU_MASK
 
 const name = exports.name = {}
 
-name.encode = function (str, buf, offset, mail = false) {
+name.encode = function (str, buf, offset, { mail = false } = {}) {
   if (!buf) buf = Buffer.alloc(name.encodingLength(str))
   if (!offset) offset = 0
   const oldOffset = offset
@@ -58,7 +58,7 @@ name.encode = function (str, buf, offset, mail = false) {
 
 name.encode.bytes = 0
 
-name.decode = function (buf, offset, mail = false) {
+name.decode = function (buf, offset, { mail = false } = {}) {
   if (!offset) offset = 0
 
   const list = []
@@ -274,7 +274,7 @@ rsoa.encode = function (data, buf, offset) {
   offset += 2
   name.encode(data.mname, buf, offset)
   offset += name.encode.bytes
-  name.encode(data.rname, buf, offset, true)
+  name.encode(data.rname, buf, offset, { mail: true })
   offset += name.encode.bytes
   buf.writeUInt32BE(data.serial || 0, offset)
   offset += 4
@@ -303,7 +303,7 @@ rsoa.decode = function (buf, offset) {
   offset += 2
   data.mname = name.decode(buf, offset)
   offset += name.decode.bytes
-  data.rname = name.decode(buf, offset, true)
+  data.rname = name.decode(buf, offset, { mail: true })
   offset += name.decode.bytes
   data.serial = buf.readUInt32BE(offset)
   offset += 4
@@ -1027,7 +1027,7 @@ rrp.encode = function (data, buf, offset) {
   const oldOffset = offset
 
   offset += 2 // Leave space for length
-  name.encode(data.mbox || '.', buf, offset, true)
+  name.encode(data.mbox || '.', buf, offset, { mail: true })
   offset += name.encode.bytes
   name.encode(data.txt || '.', buf, offset)
   offset += name.encode.bytes
@@ -1044,7 +1044,7 @@ rrp.decode = function (buf, offset) {
 
   const data = {}
   offset += 2
-  data.mbox = name.decode(buf, offset, true) || '.'
+  data.mbox = name.decode(buf, offset, { mail: true }) || '.'
   offset += name.decode.bytes
   data.txt = name.decode(buf, offset) || '.'
   offset += name.decode.bytes

--- a/test.js
+++ b/test.js
@@ -310,6 +310,36 @@ tape('name_encoding', function (t) {
   t.ok(packet.name.encode.bytes === 1, 'name encoding length matches')
   dd = packet.name.decode(buf, offset)
   t.ok(data === dd, 'encode/decode matches')
+  offset += packet.name.encode.bytes
+
+  data = 'a.b.c.d.example.com'
+  packet.name.encode(data, buf, offset, true)
+  t.ok(packet.name.encode.bytes === 21, 'name (mail) encoding length matches')
+  dd = packet.name.decode(buf, offset)
+  t.ok(data === dd, 'encode/decode matches')
+  offset += packet.name.encode.bytes
+
+  data = 'a\\.b.c.d.example.com'
+  packet.name.encode(data, buf, offset, true)
+  t.ok(packet.name.encode.bytes === 21, 'name (mail) encoding length matches')
+  dd = packet.name.decode(buf, offset, true)
+  t.ok(data === dd, 'encode/decode matches')
+  offset += packet.name.encode.bytes
+
+  data = 'a\\.b\\.c.d.example.com'
+  packet.name.encode(data, buf, offset, true)
+  t.ok(packet.name.encode.bytes === 21, 'name (mail) encoding length matches')
+  dd = packet.name.decode(buf, offset, true)
+  t.ok(data === dd, 'encode/decode matches')
+  offset += packet.name.encode.bytes
+
+  data = 'root\\.mail'
+  packet.name.encode(data, buf, offset, true)
+  t.ok(packet.name.encode.bytes === 11, 'name (mail) encoding length matches')
+  dd = packet.name.decode(buf, offset, true)
+  t.ok(data === dd, 'encode/decode matches')
+  offset += packet.name.encode.bytes
+
   t.end()
 })
 

--- a/test.js
+++ b/test.js
@@ -313,30 +313,37 @@ tape('name_encoding', function (t) {
   offset += packet.name.encode.bytes
 
   data = 'a.b.c.d.example.com'
-  packet.name.encode(data, buf, offset, true)
+  packet.name.encode(data, buf, offset, { mail: false })
+  t.ok(packet.name.encode.bytes === 21, 'name (mail) encoding length matches')
+  dd = packet.name.decode(buf, offset)
+  t.ok(data === dd, 'encode/decode matches')
+  offset += packet.name.encode.bytes
+
+  data = 'a.b.c.d.example.com'
+  packet.name.encode(data, buf, offset, { mail: true })
   t.ok(packet.name.encode.bytes === 21, 'name (mail) encoding length matches')
   dd = packet.name.decode(buf, offset)
   t.ok(data === dd, 'encode/decode matches')
   offset += packet.name.encode.bytes
 
   data = 'a\\.b.c.d.example.com'
-  packet.name.encode(data, buf, offset, true)
+  packet.name.encode(data, buf, offset, { mail: true })
   t.ok(packet.name.encode.bytes === 21, 'name (mail) encoding length matches')
-  dd = packet.name.decode(buf, offset, true)
+  dd = packet.name.decode(buf, offset, { mail: true })
   t.ok(data === dd, 'encode/decode matches')
   offset += packet.name.encode.bytes
 
   data = 'a\\.b\\.c.d.example.com'
-  packet.name.encode(data, buf, offset, true)
+  packet.name.encode(data, buf, offset, { mail: true })
   t.ok(packet.name.encode.bytes === 21, 'name (mail) encoding length matches')
-  dd = packet.name.decode(buf, offset, true)
+  dd = packet.name.decode(buf, offset, { mail: true })
   t.ok(data === dd, 'encode/decode matches')
   offset += packet.name.encode.bytes
 
   data = 'root\\.mail'
-  packet.name.encode(data, buf, offset, true)
+  packet.name.encode(data, buf, offset, { mail: true })
   t.ok(packet.name.encode.bytes === 11, 'name (mail) encoding length matches')
-  dd = packet.name.decode(buf, offset, true)
+  dd = packet.name.decode(buf, offset, { mail: true })
   t.ok(data === dd, 'encode/decode matches')
   offset += packet.name.encode.bytes
 


### PR DESCRIPTION
According to RFC 1035 (but initially defined in RFC 883), email addresses can be represented as domain names in SOA (RNAME) and RP (MBOX) Records. An email address consists of two parts, a local part and the domain (`<local part>@<domain>`). Currently, `dns-packet` does not support proper processing of email addresses if the local part contains dots (`.`). E-mail DNS labels in the local part are allowed to contain a dot, which must be escaped by `\.` in the representation format. With wire format, the label size is simply set to span the entire label, including all dots.

**SOA (RFC 1035):**
> The DNS encodes the `<local-part>` as a single label, and encodes the `<mail-domain>` as a domain name.  The single label from the `<local-part>` is prefaced to the domain name from `<mail-domain>` to form the domain name corresponding to the mailbox.  Thus the mailbox `HOSTMASTER@SRI-NIC.ARPA` is mapped into the domain name `HOSTMASTER.SRI-NIC.ARPA`.  If the `<local-part>` contains dots or other special characters, its representation in a master file will require the use of backslash quoting to ensure that the domain name is properly encoded.  For example, the mailbox `Action.domains@ISI.EDU` would be represented as `Action\.domains.ISI.EDU`.


**RP (RFC 1183):**
> The first field, `<mbox-dname>`, is a domain name that specifies the mailbox for the responsible person. Its format in master files uses the DNS convention for mailbox encoding, identical to that used for the RNAME mailbox field in the SOA RR.

**dig example:**
```bash
# dig soa powerdns.com
; <<>> DiG 9.18.12-0ubuntu0.22.04.2-Ubuntu <<>> soa powerdns.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 59258
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 65494
;; QUESTION SECTION:
;powerdns.com.			IN	SOA

;; ANSWER SECTION:
powerdns.com.		2023	IN	SOA	pdns-public-ns1.powerdns.com. peter\.van\.dijk.powerdns.com. 2023082401 10800 3600 604800 3600

;; Query time: 0 msec
;; SERVER: 127.0.0.53#53(127.0.0.53) (UDP)
;; WHEN: Fri Aug 25 11:30:41 CEST 2023
;; MSG SIZE  rcvd: 108
```

**dns-packet example after this change:**
![image](https://github.com/mafintosh/dns-packet/assets/7535523/d3439399-9d00-4fdf-a47a-3510ae559eb4)

`peter\.van\.dijk.powerdns.com` -> `peter.van.dijk@powerdns.com`

This PR should also fix #90