### PR TITLE
 Implement QU bit support in question encoder/decoder

### DIFF
--- a/index.js
+++ b/index.js
@@ -1609,7 +1609,7 @@ question.encode = function (q, buf, offset) {
   buf.writeUInt16BE(types.toType(q.type), offset)
   offset += 2
 
-  buf.writeUInt16BE(classes.toClass(q.class === undefined ? 'IN' : q.class), offset)
+  buf.writeUInt16BE(((q.qu_bit === undefined || !q.qu_bit) ? 0 : QU_MASK) | classes.toClass(q.class === undefined ? 'IN' : q.class), offset)
   offset += 2
 
   question.encode.bytes = offset - oldOffset
@@ -1630,11 +1630,9 @@ question.decode = function (buf, offset) {
   q.type = types.toString(buf.readUInt16BE(offset))
   offset += 2
 
-  q.class = classes.toString(buf.readUInt16BE(offset))
+  q.qu_bit = (buf.readUInt16BE(offset) & QU_MASK) != 0;
+  q.class = q.qu_bit ? classes.toString(buf.readUInt16BE(offset) - QU_MASK) : classes.toString(buf.readUInt16BE(offset));
   offset += 2
-
-  const qu = !!(q.class & QU_MASK)
-  if (qu) q.class &= NOT_QU_MASK
 
   question.decode.bytes = offset - oldOffset
   return q

--- a/index.js
+++ b/index.js
@@ -1630,8 +1630,8 @@ question.decode = function (buf, offset) {
   q.type = types.toString(buf.readUInt16BE(offset))
   offset += 2
 
-  q.qu_bit = (buf.readUInt16BE(offset) & QU_MASK) != 0;
-  q.class = q.qu_bit ? classes.toString(buf.readUInt16BE(offset) - QU_MASK) : classes.toString(buf.readUInt16BE(offset));
+  q.qu_bit = (buf.readUInt16BE(offset) & QU_MASK) !== 0
+  q.class = q.qu_bit ? classes.toString(buf.readUInt16BE(offset) - QU_MASK) : classes.toString(buf.readUInt16BE(offset))
   offset += 2
 
   question.decode.bytes = offset - oldOffset

--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ const RESPONSE_FLAG = 1 << 15
 const FLUSH_MASK = 1 << 15
 const NOT_FLUSH_MASK = ~FLUSH_MASK
 const QU_MASK = 1 << 15
-const NOT_QU_MASK = ~QU_MASK
 
 const name = exports.name = {}
 

--- a/test.js
+++ b/test.js
@@ -164,6 +164,34 @@ tape('query', function (t) {
     }]
   })
 
+  testEncoder(t, packet, {
+    type: 'query',
+    questions: [{
+      type: 'A',
+      class: 'IN',
+      name: 'hello.a.com',
+      qu_bit: false
+    }, {
+      type: 'SRV',
+      name: 'hello.srv.com',
+      qu_bit: false
+    }]
+  })
+
+  testEncoder(t, packet, {
+    type: 'query',
+    questions: [{
+      type: 'A',
+      class: 'IN',
+      name: 'hello.a.com',
+      qu_bit: true
+    }, {
+      type: 'SRV',
+      name: 'hello.srv.com',
+      qu_bit: true
+    }]
+  })
+
   t.end()
 })
 


### PR DESCRIPTION
This commit fix current QU bit implementation that may be used in mDNS protocol. Indeed, until now, if a packet with QU bit set is received, it is decoded as:

{

  ...

  questions: [
    {
      name: '...',
      type: 'PTR',
      class: 'UNKNOWN_32769'
    },
    {
      name: '...',
      type: 'PTR',
      class: 'UNKNOWN_32769'
    }
  ],

  ...

}

Instead of :

{

  ...

  questions: [
    {
      name: '...',
      type: 'PTR',
      class: 'IN'
    },
    {
      name: '...',
      type: 'PTR',
      class: 'IN'
    }
  ],

  ...

}

This commit adds a proper QU bit support via the qu_bit field. It enables:

- The encoder to parse properly both the class and the QU bit
- THe decoder to encode a DNS packet with the QU bit set